### PR TITLE
Adding infra from cto-ai config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,404 @@
-# Overview
+# Depoy Infrastructure from IaC using CTO.ai
 
-This repo includes a complete Digital Ocean infrastructure complete with Kubernetes, Container Registry, Postgres, Spaces, Load Balancers
-SSL (via LetsEncrypt) and Project Resource Management all built using CDKTF & Terraform Cloud.
+This repo includes a complete Digital Ocean infrastructure with Kubernetes, Container Registry, MySQL, Postgres, Redis, Load Balancers and Project Resource Management all built using CDKTF & Terraform Cloud.
 
 The repo also includes a PaaS workflow integration with CTO.ai that streamlines Developer Experience for utilizing the infrastructure, 
 which includes interative workflows that work in the CLI & Slack, but also full CI/CD & Preview Environments for all delivery.
 
+## Pre-requesites
+* Docker, Node (NVM) 12+ & npm installed
+* Sign up for CTO.ai, setup CTO.ai team
+* Install Ops CLI, Connect Github & Slack
 
-## Legend
+Follow the CTO.ai [documentation](https://cto.ai/docs/gettingstarted) to get your environment ready for start using this workflows
 
-## Setup
+## DigitalOcean Infrastructure
+These workflows allows to manage Crystal Commerce Infrastructure over DigitalOcean, the resources that are defined for be managed are the following.
+* Docker Registry
+* Kubernetes Cluster
+* MySQL Databases
+* Postgres Databases
+* Redis Databases
+* Load balancers
 
-### Pre-requesites
-### Environment
-### Setup Digital Ocean
-### Setup Terraform Cloud
-### Setup CTO.ai Workflow
-#### Secrets
-#### Configs
-#### Outputs
+You can add or remove resources changing the code of this repository or by editing the configuration parameters in your CTO.ai [team]().
 
-## Getting Started
-### Building Workflows
-### Publishing Workflows
-### Running Workflows
-### Custom Workflows
+## Commands
+The following are the commands already implemented in this repository and are able to run from the **CLI** or **Slack**
+
+### Sign In
+In first place you need to sign in into the CTO.ai plataform for that you can run in your **CLI** the following command.
+
+```
+ops account:signin
+```
+your browser goings to pops up asking for login credentials, once done you can go back to the **CLI**
+```
+💻 CTO.ai - The CLI built for Teams 🚀
+
+👋 Welcome to the The Ops CLI! 
+
+Authenticating using Single Sign On... Finished
+
+Authenticating... Done!
+
+👋 Welcome back demo-user!
+```
+
+### Team switch
+You need to be sure that you are running in the right CTO.ai team, you can do it using the following command.
+
+```
+ops team:switch
+```
+Then select the desired team
+```
+🔍 Searching for your teams... Done
+Here's the list of your teams:
+
+ Select a team (Use arrow keys or type to search)
+→ demo-user
+  cto-ai 
+```
+### Setup
+This command deploys/updates your infrastructure reading its configuration from your CTO.ai team, the following are the parameters related with the infrastructure deployment
+- **DO_DEV_K8S_CONFIG**: Kubernetes configuration for **DEV** environment.
+- **DO_STG_K8S_CONFIG**: Kubernetes configuration for **STG** environment.
+- **DO_PRD_K8S_CONFIG**: Kubernetes configuration for **PRD** environment.
+- **DO_DEV_REDIS_CONFIG**: Redis configuration for **DEV** environment.
+- **DO_STG_REDIS_CONFIG**: Redis configuration for **STG** environment.
+- **DO_PRD_REDIS_CONFIG**: Redis configuration for **PRD** environment.
+- **DO_DEV_POSTGRES_CONFIG**: Postgres configuration for **DEV** environment.
+- **DO_STG_POSTGRES_CONFIG**: Postgres configuration for **STG** environment.
+- **DO_PRD_POSTGRES_CONFIG**: Postgres configuration for **PRD** environment.
+- **DO_DEV_MYSQL_CONFIG**: MySQL configuration for **DEV** environment.
+- **DO_STG_MYSQL_CONFIG**: MySQL configuration for **STG** environment.
+- **DO_PRD_MYSQL_CONFIG**: MySQL configuration for **PRD** environment.
+
+You can check the current values for this parameters going to your CTO.ai [team]( ). In a later section this parameters would be explained in detail.
+
+Then you can deploy/setup your infrastructure with the following command
+
+```
+ops run setup
+```
+for almost all commands you going to be asked for the environment
+```
+Select a •Command, •Pipeline or •Service to run →
+🌎 = Public 🔑 = Private 🖥  = Local  🔍 Search:  • 🔑  setup - Setup Kubernetes infrastructure on Digital Ocean
+⚙️  Running setup...
+
+🛠 Loading the do-k8s stack for the cto-ai team...
+
+What is the name of the environment? [dev]: dev
+```
+Then all your infrastructure would be deployed/updated a the end you going to get some information about the resources deployed.
+```
+.
+.
+.
+    urn: 'do:vpc:ac43df94-962a-414e-9e1f-b0dfc0755f6a'
+  },
+  'cross-stack-output-digitalocean_container_registryregistry-do-k8s-registryendpoint': 'registry.digitalocean.com/cto-ai',
+  registry: {
+    createdAt: '2022-03-04 16:40:48 +0000 UTC',
+    endpoint: 'registry.digitalocean.com/cto-ai',
+    id: 'cto-ai',
+    name: 'cto-ai',
+    region: 'fra1',
+    serverUrl: 'registry.digitalocean.com',
+    storageUsageBytes: 1901222912,
+    subscriptionTierSlug: 'professional'
+  }
+}
+👀 Check your Digital Ocean dashboard or Lens for status.
+
+Happy Workflowing!
+```
+### Destroy
+This command is for destroy infrstructure or a service, you need to be **extremly careful** with this one.
+```
+ops run destroy
+```
+you going to get all the info about the destroy process, a the end a summary of the destroyed resources would be shown.
+```
+Destroying Stack: stg-do-k8s
+Resources
+ ✔ DIGITALOCEAN_DATABAS                     digitalocean_database_cluster.stg-do-k8
+   E_CLUSTER                                s-postgres
+ ✔ DIGITALOCEAN_DATABAS                     digitalocean_database_cluster.stg-do-k8
+   E_CLUSTER                                s-redis-1
+ ✔ DIGITALOCEAN_DATABAS                     digitalocean_database_cluster.stg-do-k8
+   E_CLUSTER                                s-redis-2
+ ✔ DIGITALOCEAN_DATABAS                     digitalocean_database_db.stg-do-k8s-db
+   E_DB
+ ✔ DIGITALOCEAN_DATABAS                     digitalocean_database_user.stg-do-k8s-d
+   E_USER                                   b-user
+ ✔ DIGITALOCEAN_KUBERNE                     digitalocean_kubernetes_cluster.stg-do-
+   TES_CLUSTER                              k8s-k8s
+ ✔ DIGITALOCEAN_PROJECT                     digitalocean_project.stg-do-k8s-project
+ ✔ DIGITALOCEAN_PROJECT                     digitalocean_project_resources.stg-do-k
+   _RESOURCES                               8s-resources
+ ✔ DIGITALOCEAN_VPC                         digitalocean_vpc.stg-do-k8s-vpc
+
+Summary: 9 destroyed.
+```
+### Deploy
+This command deploys a Service Docker Image into Kubernetes cluster applying all configurations defined for each service in CTO.ai [team]( ). it includes a certain number of replicas, a load balancer, health checks and set some environment variables. The parameters that are consider for this config are the following.
+
+- **DO_DEV_SERVICES**: Services settings for **DEV** environment.
+- **DO_STG_SERVICES**: Services settings for **STG** environment.
+- **DO_PRD_SERVICES**: Services settings for **PRD** environment.
+
+The command is the following.
+```
+ops run deploy
+```
+We going to be asked for which service we want to deploy (service are get from config)
+```
+Select a •Command, •Pipeline or •Service to run →
+🌎 = Public 🔑 = Private 🖥  = Local  🔍 Search:  • 🔑  deploy - Deploy a service to Kubernetes infrastructure on DigitalOcean
+⚙️  Running deploy...
+
+🛠 Loading the do-k8s stack for the cto-ai team...
+
+What is the name of the environment?: dev
+What is the name of the application repo?:
+  my-service-app
+> my-service-api
+  my-service-backend
+```
+then it ask again for the tag of the image that we want to deploy
+```
+What is the name of the environment?: dev
+What is the name of the application repo?: my-service-api
+What is the name of the tag or branch?: do-dev
+```
+after the process completes we got a confirmation
+```
+✅ Deployed. Load Balancer may take some time to provision on your first deploy.
+✅ View state in Terraform Cloud (https://app.terraform.io/app/cto-ai/workspaces/).
+👀 Check your Digital Ocean dashboard or Lens.app for status & IP.
+
+Happy Workflowing!
+```
+
+### Vault
+This command allows to manage secrets in Kubernetes, these secrets are inyected as environment variables to your pods in Kubernetes.
+
+* **Init**<br>
+This command option allows you to initialize the vault, and it should be executed when you create a new Kubernetes cluster.
+```
+ops run . vault init
+``` 
+* **Set**<br>
+Set command option creates or update a new key/value pair in the vault
+```
+ops run . vault set
+```
+then you just need to provide the environment, key and value
+```
+⚙️  Running vault...
+🛠 Loading the do-k8s stack for the cto-ai team...
+What is the name of the environment?: dev
+What is the key for the secret?: test-key
+What is the value for the secret?: test-val
+Are you sure you want to set test-key to test-val in the dev-do-k8s? → yes
+Notice: Adding cluster credentials to kubeconfig file found in "/home/ops/.kube/config"
+Notice: Setting current-context to do-nyc3-dev-k8s-cto-ai-02022022
+
+⚡️ Confirming connection to dev-k8s-cto-ai-02022022:
+NAME                                                 STATUS   ROLES    AGE   VERSION
+dev-do-k8s-k8s-node-cto-ai-02022022-c3flc   Ready    <none>   41d   v1.22.7
+dev-do-k8s-k8s-node-cto-ai-02022022-c3flu   Ready    <none>   41d   v1.22.7
+dev-do-k8s-k8s-node-cto-ai-02022022-c8lk1   Ready    <none>   35d   v1.22.7
+
+🔐 Setting test-key to test-val on the dev-do-k8s with type string
+✅ test-key set to test-val in the dev-do-k8s vault
+```
+* **List**<br>
+This command option list all key/value pairs in the vault
+```
+ops run . vault ls
+```
+```
+Select a •Command, •Pipeline or •Service to run →
+🌎 = Public 🔑 = Private 🖥  = Local  🔍 Search:  • 🖥   vault - manage secrets vault
+⚙️  Running vault...
+🛠 Loading the do-k8s stack for the cto-ai team...
+What is the name of the environment?: dev
+Notice: Adding cluster credentials to kubeconfig file found in "/home/ops/.kube/config"
+Notice: Setting current-context to do-nyc3-dev-k8s-cto-ai-02022022
+
+⚡️ Confirming connection to dev-k8s-cto-ai-02022022:
+NAME                                                 STATUS   ROLES    AGE   VERSION
+dev-do-k8s-k8s-node-cto-ai-02022022-c3flc   Ready    <none>   41d   v1.22.7
+dev-do-k8s-k8s-node-cto-ai-02022022-c3flu   Ready    <none>   41d   v1.22.7
+dev-do-k8s-k8s-node-cto-ai-02022022-c8lk1   Ready    <none>   35d   v1.22.7
+
+🔐 dev-do-k8s has the following secrets: 
+test-key: test-val
+```
+* **Delete**<br>
+This option allows to delete any key value pair from the vault
+```
+ops run . vault rm
+```
+```
+Select a •Command, •Pipeline or •Service to run →
+🌎 = Public 🔑 = Private 🖥  = Local  🔍 Search:  • 🖥   vault - manage secrets vault
+⚙️  Running vault...
+🛠 Loading the do-k8s stack for the cto-ai team...
+What is the name of the environment?: dev
+What is the key for the secret?: test-key
+Are you sure you want to remove test-key from the dev-do-k8s vault? → yes
+Notice: Adding cluster credentials to kubeconfig file found in "/home/ops/.kube/config"
+Notice: Setting current-context to do-nyc3-dev-k8s-cto-ai-02022022
+
+⚡️ Confirming connection to dev-k8s-cto-ai-02022022:
+NAME                                                 STATUS   ROLES    AGE   VERSION
+dev-do-k8s-k8s-node-cto-ai-02022022-c3flc   Ready    <none>   42d   v1.22.7
+dev-do-k8s-k8s-node-cto-ai-02022022-c3flu   Ready    <none>   42d   v1.22.7
+dev-do-k8s-k8s-node-cto-ai-02022022-c8lk1   Ready    <none>   36d   v1.22.7
+
+🔐 Deleting test-key from the dev-do-k8s vault
+✅ test-key removed from the dev-do-k8s vault
+```
+* **Destroy**<br>
+This vault option destroys the vault from the Kubernetes cluster, so you need to be **extremly careful** with this, because after the deletion you going to lose all you key/value for the selected environment
+```
+ops run . vault destroy
+```
+
+## Service and Infrastructure Configuration
+Most of the changes against infrastructure and services can be done without modify the code, just adjusting the parameters in CTO.ai [team]( ) config.Then you can re-run `ops run setup` for apply the changes in infrastructure and re-run `ops run deploy` for apply changes in services. 
+
+## Kubernetes capacity setup
+These parameters set the Kubernetes capacity cluster depending on the environment and taking this values from the `config` in the CTO's [team]( ). The definition of the size of the cluster is given in the following 3 `config` parameters:
+
+- **DO_DEV_K8S_CONFIG** 
+- **DO_STG_K8S_CONFIG**
+- **DO_PRD_K8S_CONFIG**
+
+One parameter for each environment, this config parameter is a string cotaining a `json` in the following format:
+
+```
+{ 
+ "dropletSize": "s-1vcpu-2gb", 
+ "nodeCount": 3, 
+ “minNodes": 1, 
+ "maxNodes": 5, 
+ "autoScale": true 
+}
+```
+### Redis, MySQL, Postgres Cluster Capacity/Scale Setup
+The same aproach can be used for other resources, like in this case a `Redis`, `MySQL` and `Postgres` clusters which is defined by the following parameters:
+
+- **DO_DEV_REDIS_CONFIG** 
+- **DO_STG_REDIS_CONFIG**
+- **DO_PRD_REDIS_CONFIG**
+- **DO_DEV_MYSQL_CONFIG** 
+- **DO_STG_MYSQL_CONFIG**
+- **DO_PRD_MYSQL_CONFIG**
+- **DO_DEV_POSTGRES_CONFIG** 
+- **DO_STG_POSTGRES_CONFIG**
+- **DO_PRD_POSTGRES_CONFIG**
+
+In this case the redis clustre config string has the following format.
+
+```
+[
+  {
+    "name": "my-service-api-redis",
+    "dropletSize": "db-s-1vcpu-1gb",
+    "nodeCount": 1,
+    "version": "6"
+  },
+  {
+    "name": "my-service-app-redis",
+    "dropletSize": "db-s-1vcpu-1gb",
+    "nodeCount": 1,
+    "version": "6"
+  }
+]
+```
+The same aproach is used for MySQL and Postgres
+```
+[
+  {
+    "name": "my-service-api-db",
+    "dropletSize": "db-s-1vcpu-1gb",
+    "nodeCount": 1,
+    "version": "8",
+    "db_user": "my-service-api",
+    "db_name": "dev-my-service-api-db",
+    "auth": "mysql_native_password"
+  },
+  {
+    "name": "my-service-app-db",
+    "dropletSize": "db-s-1vcpu-1gb",
+    "nodeCount": 1,
+    "version": "8",
+    "db_user": "my-service-app-db",
+    "db_name": "dev-my-service-app-db",
+    "auth": "mysql_native_password"
+  }
+]
+```
+### Services Parameters Definition
+To setup multiple services in the same cluster, we store all the deployment paramenters like port, replicas, etc. as `config` parameter in CTO.ai [team]( ), it would makes deployments easier. The variables as shown before would be by environment as follows.
+
+- **DO_DEV_SERVICES** 
+- **DO_STG_SERVICES**
+- **DO_PRD_SERVICES**
+
+It containes an array of services with parameters in `json` format.
+
+```
+{ 
+	"sample-app": 
+		{ 
+			"replicas" : 2, 
+			"ports" : [ { 
+				"containerPort" : 3000 
+			} ], 
+			"lb_ports" : [ { 
+				"protocol": "TCP", 
+				"port": 3000, 
+				"targetPort": 3000 
+			} ], 
+			"hc_port": 3000 
+		 }
+}
+```
+### Maping vault secrets to environment variables in a pod
+Since in many cases you have to deploy multiple services using the same vault, you can find cases in which a varable name is the same for different services and generates conflicts, in order to solve this issue you can use `map` parameter in the json string for services, this allows you to map this variables. following is the json for a sample service.
+
+```
+{ 
+	"sample-expressjs": { 
+				"replicas" : 2, 
+				"ports" : [ { 
+					"containerPort" : 3000 
+					} ], 
+				"lb_ports" : [ {
+					 "protocol": "TCP", 
+					"port": 3000, 
+					"targetPort": 3000 
+					} ], 
+				"hc_port": 3000, 
+				"sticky_sessions": "no",
+				"map": { 
+					"DB_HOST" : "SP_DB_HOST", 
+					"DB_USER":"SP_DB_USER", 
+					"DB_PASS":"SP_DB_PASS", 
+					"DB_PORT":"SP_DB_PORT", 
+					"DB_NAME":"SP_DB_NAME"
+				}
+	 } 
+}
+```
+each pair maps **pod env variable** to **vault variable** so for example **DB_HOST** in the pod going to have the value of **SP_DB_HOST** from the vault.
 
 ## License 
 MIT

--- a/ops.yml
+++ b/ops.yml
@@ -1,6 +1,6 @@
 version: "1"
 commands:
-  - name: setup:0.2.0
+  - name: setup:0.1.0
     run: ./node_modules/.bin/ts-node /ops/src/setup.ts
     description: "Setup Kubernetes infrastructure on DigitalOcean"
     env:
@@ -17,6 +17,12 @@ commands:
         - DEV_DO_K8S_STATE
         - STG_DO_K8S_STATE
         - PRD_DO_K8S_STATE
+        - DO_DEV_K8S_CONFIG
+        - DO_STG_K8S_CONFIG
+        - DO_PRD_K8S_CONFIG
+        - DO_DEV_REDIS_CONFIG
+        - DO_DEV_POSTGRES_CONFIG
+        - DO_DEV_MYSQL_CONFIG
   - name: deploy:0.1.0
     run: ./node_modules/.bin/ts-node /ops/src/deploy.ts
     description: "Deploy a service to Kubernetes infrastructure on DigitalOcean"
@@ -34,6 +40,9 @@ commands:
         - DEV_DO_K8S_STATE
         - STG_DO_K8S_STATE
         - PRD_DO_K8S_STATE
+        - DO_DEV_SERVICES
+        - DO_STG_SERVICES
+        - DO_PRD_SERVICES
   - name: destroy:0.1.0
     run: ./node_modules/.bin/ts-node /ops/src/destroy.ts
     description: "Destroy resources in your Kubernetes infrastructure on DigitalOcean"
@@ -51,6 +60,12 @@ commands:
         - DEV_DO_K8S_STATE
         - STG_DO_K8S_STATE
         - PRD_DO_K8S_STATE
+        - DO_DEV_K8S_CONFIG
+        - DO_STG_K8S_CONFIG
+        - DO_PRD_K8S_CONFIG
+        - DO_DEV_SERVICES
+        - DO_STG_SERVICES
+        - DO_PRD_SERVICES
   - name: vault:0.1.0
     run: ./node_modules/.bin/ts-node /ops/src/vault.ts
     description: "manage secrets vault"

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,15 +62,15 @@
       }
     },
     "@cdktf/hcl2cdk": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@cdktf/hcl2cdk/-/hcl2cdk-0.9.2.tgz",
-      "integrity": "sha512-Z5t2qLFFfYm7xW6De5z1/2n/m9t6FlltYoYRpLcFLza2FD5n/Z0xxez6vaQQ8jdFpRIhjGYbMmTbewTFkMaeJA==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@cdktf/hcl2cdk/-/hcl2cdk-0.9.4.tgz",
+      "integrity": "sha512-sUg9GsmaFpqqfoGcqibMEDHozMQhaDOxBT3Dz3ioNc0SSWhBpDRwrlctK3rNNKvWUetEeUr28L7SJR/I0TSd+Q==",
       "requires": {
         "@babel/generator": "^7.17.3",
         "@babel/template": "^7.16.7",
         "@babel/types": "^7.17.0",
-        "@cdktf/hcl2json": "0.9.2",
-        "@cdktf/provider-generator": "0.9.2",
+        "@cdktf/hcl2json": "0.9.4",
+        "@cdktf/provider-generator": "0.9.4",
         "camelcase": "^6.3.0",
         "glob": "7.2.0",
         "graphology": "^0.24.1",
@@ -82,20 +82,20 @@
       }
     },
     "@cdktf/hcl2json": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@cdktf/hcl2json/-/hcl2json-0.9.2.tgz",
-      "integrity": "sha512-rWLaLaBZjt8ZZmzQ9TiBqovRkDGe0act+7R0ZCG15eby1imuD/IElUkuKCwByfKroNtM8+iRx2ohs8BOPn22pw==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@cdktf/hcl2json/-/hcl2json-0.9.4.tgz",
+      "integrity": "sha512-dZZUi94C7TFs0E8IubNYu38mBncVlQVUeGp6nA3tYxs/ue1igKqx7+mWfZP7NYVOSlggMGRNaTts6ZA0UAtOYQ==",
       "requires": {
         "@types/node-fetch": "^2.6.1",
         "node-fetch": "^2.6.7"
       }
     },
     "@cdktf/provider-generator": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@cdktf/provider-generator/-/provider-generator-0.9.2.tgz",
-      "integrity": "sha512-wcfDFsBmvBN8dUtg7U6NzFSYGD6mZN7h7jLJ39RMyoscbk/I2khy5lwyVd7yzQV3bvwMyRwIvYswQJ3WOkVZTw==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@cdktf/provider-generator/-/provider-generator-0.9.4.tgz",
+      "integrity": "sha512-06sfpBTn3+PqiU/XP3RQ6FO6M+GxzmHo6yIJk9r5x1QmIlitDE9tdogXqmAVVHB4nGRL/v7SXefcrOHrOkl1YQ==",
       "requires": {
-        "@cdktf/hcl2json": "0.9.2",
+        "@cdktf/hcl2json": "0.9.4",
         "codemaker": "^0.22.0",
         "fs-extra": "^8.1.0",
         "is-valid-domain": "^0.1.5",
@@ -508,9 +508,9 @@
       "integrity": "sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ=="
     },
     "cdktf": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.9.2.tgz",
-      "integrity": "sha512-apdNKXP5X20JG99Zby9A3NBjzYcoKQKvmDjNw81/QQz0I30jnDqh0NvxkrpyJuP4/93Dq26RqOs/EjyEZB9Lfg==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/cdktf/-/cdktf-0.9.4.tgz",
+      "integrity": "sha512-CuTCNVV3Goptnq3daPVfs9boODEoIrjy09XAj9nkApcozgidPkNIkDcaJCo/7q3rxnoblsK9u2nj6CDUB8cTIg==",
       "requires": {
         "archiver": "5.3.0",
         "json-stable-stringify": "^1.0.1"
@@ -851,13 +851,13 @@
       }
     },
     "cdktf-cli": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/cdktf-cli/-/cdktf-cli-0.9.2.tgz",
-      "integrity": "sha512-Ep42WrCFpkuxLAozEFyAvYA8UUKI3hkk+rQFhkcFQ92WWI0U3xill1Gjp3DtkG0/WbW0pi6pa1M8Ft7ePNK1tw==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/cdktf-cli/-/cdktf-cli-0.9.4.tgz",
+      "integrity": "sha512-C7nL+AVA2ltmRhFdAb6yinXzjumRIAyaNi1p5QyZpythrg6+GThxZS/We+s8GIA000uIrPMvesuHCE+dGxkssw==",
       "requires": {
-        "@cdktf/hcl2cdk": "0.9.2",
-        "@cdktf/hcl2json": "0.9.2",
-        "cdktf": "0.9.2",
+        "@cdktf/hcl2cdk": "0.9.4",
+        "@cdktf/hcl2json": "0.9.4",
+        "cdktf": "0.9.4",
         "constructs": "^10.0.25",
         "jsii": "^1.54.0",
         "jsii-pacmak": "^1.54.0",
@@ -1130,9 +1130,9 @@
       }
     },
     "date-format": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.3.tgz",
-      "integrity": "sha512-7P3FyqDcfeznLZp2b+OMitV9Sz2lUnsT87WaTat9nVwqsBkTzPG3lPLNwW3en6F4pHUiWzr6vb8CLhjdK9bcxQ=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.4.tgz",
+      "integrity": "sha512-/jyf4rhB17ge328HJuJjAcmRtCsGd+NDeAtahRBTaK6vSPR6MO5HlrAit3Nn7dVjaa6sowW0WXt8yQtLyZQFRg=="
     },
     "debug": {
       "version": "4.3.3",
@@ -1470,9 +1470,9 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
     },
     "has-tostringtag": {
       "version": "1.0.0",
@@ -1654,9 +1654,9 @@
       }
     },
     "is-valid-domain": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/is-valid-domain/-/is-valid-domain-0.1.5.tgz",
-      "integrity": "sha512-ilzfGo1kXzoVpSLplJWOexoiuAc6mRK+vPlNAeEPVJ29RagETpCz0izg6CZfY72DCuA+PCrEAEJeaecRLMNq5Q==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-valid-domain/-/is-valid-domain-0.1.6.tgz",
+      "integrity": "sha512-ZKtq737eFkZr71At8NxOFcP9O1K89gW3DkdrGMpp1upr/ueWjj+Weh4l9AI4rN0Gt8W2M1w7jrG2b/Yv83Ljpg==",
       "requires": {
         "punycode": "^2.1.1"
       }
@@ -2013,9 +2013,9 @@
       }
     },
     "jsii-srcmak": {
-      "version": "0.1.482",
-      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.482.tgz",
-      "integrity": "sha512-Dr7eCmWXtYSPMODMxJxbzf6m5+iFH9WcKtmwWDFwcUke5bxTndovEKkK/GKHKD1sNZcF6FHX2Nak5Lib0bPUTw==",
+      "version": "0.1.492",
+      "resolved": "https://registry.npmjs.org/jsii-srcmak/-/jsii-srcmak-0.1.492.tgz",
+      "integrity": "sha512-0DBrpEWyMCRYi0wo3K8vQSlpS1Aet3mXczYwPsnBfcNR19ya8gICr2QgNq/isjJmZx+yt1MCPRBcakrxtYOUWg==",
       "requires": {
         "fs-extra": "^9.1.0",
         "jsii": "^1.54.0",
@@ -2135,15 +2135,15 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "log4js": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.1.tgz",
-      "integrity": "sha512-iUiYnXqAmNKiIZ1XSAitQ4TmNs8CdZYTAWINARF3LjnsLN8tY5m0vRwd6uuWj/yNY0YHxeZodnbmxKFUOM2rMg==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.2.tgz",
+      "integrity": "sha512-k80cggS2sZQLBwllpT1p06GtfvzMmSdUCkW96f0Hj83rKGJDAu2vZjt9B9ag2vx8Zz1IXzxoLgqvRJCdMKybGg==",
       "requires": {
-        "date-format": "^4.0.3",
+        "date-format": "^4.0.4",
         "debug": "^4.3.3",
-        "flatted": "^3.2.4",
+        "flatted": "^3.2.5",
         "rfdc": "^1.3.0",
-        "streamroller": "^3.0.2"
+        "streamroller": "^3.0.4"
       }
     },
     "lru-cache": {
@@ -2581,19 +2581,19 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "streamroller": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.2.tgz",
-      "integrity": "sha512-ur6y5S5dopOaRXBuRIZ1u6GC5bcEXHRZKgfBjfCglMhmIf+roVCECjvkEYzNQOXIN2/JPnkMPW/8B3CZoKaEPA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.4.tgz",
+      "integrity": "sha512-GI9NzeD+D88UFuIlJkKNDH/IsuR+qIN7Qh8EsmhoRZr9bQoehTraRgwtLUkZbpcAw+hLPfHOypmppz8YyGK68w==",
       "requires": {
-        "date-format": "^4.0.3",
-        "debug": "^4.1.1",
-        "fs-extra": "^10.0.0"
+        "date-format": "^4.0.4",
+        "debug": "^4.3.3",
+        "fs-extra": "^10.0.1"
       },
       "dependencies": {
         "fs-extra": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-          "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+          "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
@@ -2937,9 +2937,9 @@
       },
       "dependencies": {
         "yargs-parser": {
-          "version": "21.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
-          "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA=="
+          "version": "21.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg=="
         }
       }
     },

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -20,6 +20,9 @@ async function run() {
   const TFC_ORG = process.env.TFC_ORG || ''
   const STACK_TYPE = process.env.STACK_TYPE || 'do-k8s';
   const STACK_TEAM = process.env.OPS_TEAM_NAME || 'private'
+  const defaultServicesConfig = '{ "sample-app": { "replicas" : 2, "ports" : [ { "containerPort" : 3000 } ], "lb_ports" : [ { "protocol": "TCP", "port": 3000, "targetPort": 3000 } ], "hc_port": 3000 } }'
+  var servicesConfig: string;
+  
 
   await ux.print(`\n🛠 Loading the ${ux.colors.white(STACK_TYPE)} stack for the ${ux.colors.white(STACK_TEAM)} team...\n`)
 
@@ -32,14 +35,37 @@ async function run() {
       message: 'What is the name of the environment?'
     })
 
+  switch(STACK_ENV) { 
+    case 'dev': { 
+      servicesConfig = process.env.DO_DEV_SERVICES || defaultServicesConfig;
+      break; 
+    } 
+    case 'stg': { 
+      servicesConfig = process.env.DO_STG_SERVICES || defaultServicesConfig;
+      break; 
+    }
+    case 'prd': { 
+      servicesConfig = process.env.DO_PRD_SERVICES || defaultServicesConfig;
+      break; 
+    } 
+    default: { 
+      servicesConfig = defaultServicesConfig;
+      break; 
+    } 
+  }
+  
+  const jsonServicesConfig = JSON.parse(servicesConfig);
+  const servicesList = Object.keys(jsonServicesConfig);
+  
   const { STACK_REPO } = await ux.prompt<{
     STACK_REPO: string
   }>({
-      type: 'input',
+      type: 'list',
       name: 'STACK_REPO',
-      default: 'sample-app',
+      choices: servicesList,
       message: 'What is the name of the application repo?'
     })
+
 
   const { STACK_TAG } = await ux.prompt<{
     STACK_TAG: string
@@ -129,7 +155,7 @@ async function run() {
           STACK_ENV: STACK_ENV,
           STACK_TYPE: STACK_TYPE,
           STACK_REPO: STACK_REPO,
-          STACK_TAG: STACK_TAG
+          STACK_TAG: STACK_TAG,
         }
       }
     }
@@ -160,7 +186,7 @@ async function run() {
     } catch (e) {
       sdk.track([], {
         event_name: 'deployment',
-        event_action: 'failed',
+        event_action: 'failure',
         environment: STACK_ENV,
         repo: STACK_REPO,
         branch: STACK_TAG,
@@ -175,7 +201,7 @@ async function run() {
   .catch(e => {
     sdk.track([], {
       event_name: 'deployment',
-      event_action: 'failed',
+      event_action: 'failure',
       environment: STACK_ENV,
       repo: STACK_REPO,
       branch: STACK_TAG,

--- a/src/stack/cluster.ts
+++ b/src/stack/cluster.ts
@@ -16,7 +16,9 @@ interface StackProps {
 export default class Cluster extends TerraformStack{
   public vpc: Vpc
   public cluster: KubernetesCluster
-  public db: DatabaseCluster
+  public pgArr: DatabaseCluster[]
+  public redisArr: DatabaseCluster[]
+  public mysqlArr: DatabaseCluster[]
 
   public readonly props: StackProps | undefined
   public readonly id: string | undefined
@@ -58,10 +60,62 @@ export default class Cluster extends TerraformStack{
   async initialize() {
 
     //TODO: make dynamic
-    const region = 'nyc3'
-    const k8ver = '1.21.9-do.0';
-    const dropletSize = 's-1vcpu-2gb'; 
+    const region = 'nyc3';
+    const k8ver = '1.22.7-do.0';
+    const defaultK8sConfig = '{ "dropletSize": "s-1vcpu-2gb", "nodeCount": 3, "minNodes": 1, "maxNodes": 5, "autoScale": true }';
+    const defaultRedisConfig = '[{ "name":"default","dropletSize": "db-s-1vcpu-1gb", "nodeCount": 1, "version": "6" }]';
+    const defaultMySQLConfig = '[{ "name":"default","dropletSize": "db-s-1vcpu-1gb", "nodeCount": 1, "version": "8", "db_user": "root", "db_name": "default_db", "auth": "mysql_native_password" }]';
+    const defaultPostgresSQLConfig = '[{ "name": "default", "dropletSize": "db-s-1vcpu-1gb", "nodeCount": 1, "version": "8", "db_user": "root", "db_name": "default_db" }]';
+    var k8sConfig: string;
+    var redisConfig: string;
+    var mysqlConfig: string;
+    var postgresConfig: string;
+    var redisCount = 0;
+    var pgCount = 0;
+    var mysqlCount = 0;
+    
+    switch(this.env) { 
+      case 'dev': { 
+        k8sConfig = process.env.DO_DEV_K8S_CONFIG || defaultK8sConfig;
+        redisConfig = process.env.DO_DEV_REDIS_CONFIG || defaultRedisConfig;
+        mysqlConfig = process.env.DO_DEV_MYSQL_CONFIG || defaultMySQLConfig;
+        postgresConfig = process.env.DO_DEV_POSTGRES_CONFIG || defaultPostgresSQLConfig;
+        break; 
+      } 
+      case 'stg': { 
+        k8sConfig = process.env.DO_STG_K8S_CONFIG || defaultK8sConfig;
+        redisConfig = process.env.DO_STG_REDIS_CONFIG || defaultRedisConfig;
+        mysqlConfig = process.env.DO_STG_MYSQL_CONFIG || defaultMySQLConfig;
+        postgresConfig = process.env.DO_STG_POSTGRES_CONFIG || defaultPostgresSQLConfig;
+        break; 
+      }
+      case 'prd': { 
+        k8sConfig = process.env.DO_PRD_K8S_CONFIG || defaultK8sConfig;
+        redisConfig = process.env.DO_PRD_REDIS_CONFIG || defaultRedisConfig;
+        mysqlConfig = process.env.DO_PRD_MYSQL_CONFIG || defaultMySQLConfig;
+        postgresConfig = process.env.DO_PRD_POSTGRES_CONFIG || defaultPostgresSQLConfig;
+        break; 
+      } 
+      default: { 
+        k8sConfig = defaultK8sConfig;
+        redisConfig = defaultRedisConfig;
+        mysqlConfig = defaultMySQLConfig;
+        postgresConfig = defaultPostgresSQLConfig;
+        break; 
+      } 
+    }
+    const jsonK8sConfig = JSON.parse(k8sConfig);
+    const jsonRedisConfig = JSON.parse(redisConfig);
+    const jsonMySQLConfig = JSON.parse(mysqlConfig);
+    const jsonPostgresConfig = JSON.parse(postgresConfig);
 
+    const dropletSize = jsonK8sConfig.dropletSize;
+    const nodeCount = jsonK8sConfig.nodeCount;
+    const minNodes = jsonK8sConfig.minNodes;
+    const maxNodes = jsonK8sConfig.maxNodes;
+    const autoScale = jsonK8sConfig.autoScale;
+
+    
     const vpc = new Vpc(this, `${this.id}-vpc`, {
       name: `${this.env}-vpc-${this.org}-${this.entropy}`,
       region: region
@@ -74,49 +128,130 @@ export default class Cluster extends TerraformStack{
       nodePool: {
         name: `${this.id}-k8s-node-${this.org}-${this.entropy}`,
         size: dropletSize,
-        nodeCount: 3,
-        minNodes: 1,
-        maxNodes: 5
+        nodeCount: nodeCount,
+        minNodes: minNodes,
+        maxNodes: maxNodes,
+        autoScale: autoScale
       },
     });
 
-    const db = new DatabaseCluster(this, `${this.id}-postgres`, {
-      name: `${this.env}-psql-${this.org}-${this.entropy}`,
-      engine: 'pg',
-      version: '13',
-      size: 'db-s-1vcpu-1gb',
-      region: region,
-      nodeCount: 1
-    })
+    var pgArr : DatabaseCluster[]; 
+    pgArr = [];
+    pgCount = 0;
+    
+    for (let pgInstance of jsonPostgresConfig) {
+      pgCount = pgCount + 1;
+      pgArr.push(new DatabaseCluster(this, `${this.id}-pg-${pgCount}`, {
+        name: `${this.env}-${pgInstance.name}-pg-${this.org}-${this.entropy}`,
+        engine: 'pg',
+        version: pgInstance.version,
+        size: pgInstance.dropletSize,
+        region: region,
+        nodeCount: pgInstance.nodeCount
+      }))
 
-    new DatabaseUser(this, `${this.id}-db-user`, {
-      clusterId: `${db.id}`,
-      name: `root`,
-    })
+      new DatabaseUser(this, `${this.id}-db-user-${pgCount}`, {
+        clusterId: `${pgArr[pgCount-1].id}`,
+        name: pgInstance.db_user,
+      })
+  
+      new DatabaseDb(this, `${this.id}-db-${pgCount}`, {
+        clusterId: `${pgArr[pgCount-1].id}`,
+        name: pgInstance.db_name
+        // need to add ENV var for DB Pass
+      })
+    }
 
-    new DatabaseDb(this, `${this.id}-db`, {
-      clusterId: `${db.id}`,
-      name: `${this.id}`
-      // need to add ENV var for DB Pass
-    })
+    var mysqlArr : DatabaseCluster[]; 
+    mysqlArr = [];
+    mysqlCount = 0;
+
+    for (let mysqlInstance of jsonMySQLConfig) {
+      mysqlCount = mysqlCount + 1;
+      mysqlArr.push(new DatabaseCluster(this, `${this.id}-mysql-${mysqlCount}`, {
+        name: `${this.env}-${mysqlInstance.name}-mysql-${this.org}-${this.entropy}`,
+        engine: 'mysql',
+        version: mysqlInstance.version,
+        size: mysqlInstance.dropletSize,
+        region: region,
+        nodeCount: mysqlInstance.nodeCount
+      }))
+
+      const db_user = new DatabaseUser(this, `${this.id}-mysql-user-${mysqlCount}`, {
+        clusterId: `${mysqlArr[mysqlCount-1].id}`,
+        name: mysqlInstance.db_user,
+        mysqlAuthPlugin: mysqlInstance.auth
+      })
+  
+      new DatabaseDb(this, `${this.id}-mysql-db-name-${mysqlCount}`, {
+        clusterId: `${mysqlArr[mysqlCount-1].id}`,
+        name: mysqlInstance.db_name
+      })
+    }
+
+    
+
+    var redisArr : DatabaseCluster[]; 
+    redisArr = [];
+    redisCount = 0;
+    for (let redisInstance of jsonRedisConfig) {
+      redisCount = redisCount + 1;
+      redisArr.push(new DatabaseCluster(this, `${this.id}-redis-${redisCount}`, {
+        name: `${this.env}-${redisInstance.name}-redis-${this.org}-${this.entropy}`,
+        engine: 'redis',
+        version: redisInstance.version,
+        size: redisInstance.dropletSize,
+        region: region,
+        nodeCount: redisInstance.nodeCount
+      }))
+    }
+
+    var resourcesArr = redisArr.concat(pgArr);
+    resourcesArr = resourcesArr.concat(mysqlArr);
 
     const project = new Project(this, `${this.id}-project`, {
       name: `${this.env}`,
-      dependsOn:[vpc, cluster, db]
+      dependsOn: [vpc, cluster]
     })
+    
+    var resourcesUrnArr: string [];
+    var redisUrnArray: string[];
+    var pgUrnArray: string[];
+    var mysqlUrnArray: string[];
+    resourcesUrnArr = [];
+    redisUrnArray = [];
+    pgUrnArray = [];
+    mysqlUrnArray = [];
+
+
+    redisArr.forEach(function (redisInstance) {
+      redisUrnArray.push(redisInstance.urn)
+    })
+
+    pgArr.forEach(function (pgInstance) {
+      pgUrnArray.push(pgInstance.urn)
+    })
+
+    mysqlArr.forEach(function (mysqlInstance) {
+      mysqlUrnArray.push(mysqlInstance.urn)
+    })
+
+    resourcesUrnArr = redisUrnArray.concat(pgUrnArray);
+    resourcesUrnArr = resourcesUrnArr.concat(mysqlUrnArray);
 
     new ProjectResources(this, `${this.id}-resources`, {
       project: project.id,
       resources: [
-        cluster.urn,
-        db.urn,
-      ],
-      dependsOn: [ project, cluster, db ]
+        cluster.urn
+      ].concat(resourcesUrnArr),
+      dependsOn: [ project, cluster ]
     })
 
     this.vpc = vpc
     this.cluster = cluster
-    this.db = db
+    this.pgArr = pgArr
+    this.redisArr = redisArr
+    this.mysqlArr = mysqlArr
 
     new TerraformOutput(this, 'vpc', {
       value: {
@@ -133,14 +268,45 @@ export default class Cluster extends TerraformStack{
         id: this.cluster.id
       }
     })
-    new TerraformOutput(this, 'db', {
-      value: {
-        name: this.db.name,
-        host: this.db.host,
-        user: this.db.user,
-        urn: this.db.urn
-      }
-    })
+    
+    pgCount = 0;
+    for (let pgObjInstance of pgArr) {
+      pgCount = pgCount + 1;
+      new TerraformOutput(this, `pg-${pgCount}`, {
+        value: {
+          name: pgObjInstance.name,
+          host: pgObjInstance.host,
+          user: pgObjInstance.user,
+          urn: pgObjInstance.urn
+        }
+      })
+    }
+
+    mysqlCount = 0;
+    for (let mysqlObjInstance of mysqlArr) {
+      mysqlCount = mysqlCount + 1;
+      new TerraformOutput(this, `mysql-${mysqlCount}`, {
+        value: {
+          name: mysqlObjInstance.name,
+          host: mysqlObjInstance.host,
+          user: mysqlObjInstance.user,
+          urn: mysqlObjInstance.urn
+        }
+      })
+    }
+
+    redisCount = 0;
+    for (let redisObjInstance of redisArr) {
+      redisCount = redisCount + 1;
+      new TerraformOutput(this, `redis-${redisCount}`, {
+        value: {
+          name: redisObjInstance.name,
+          host: redisObjInstance.host,
+          user: redisObjInstance.user,
+          urn: redisObjInstance.urn
+        }
+      })
+    }
 
   }
 }

--- a/src/stack/index.ts
+++ b/src/stack/index.ts
@@ -44,7 +44,7 @@ export class Stack {
     await registry.initialize()
 
     // create each vpc, cluster & db
-    const cluster = new Cluster(app, `dev-${this.key}`, {
+    const cluster = new Cluster(app, `${this.env}-${this.key}`, {
       org: this.org,
       env: this.env,
       key: this.key,
@@ -54,7 +54,7 @@ export class Stack {
     })
     await cluster.initialize()
 
-    const service = new Service(app, `dev-${this.repo}-${this.key}`, {
+    const service = new Service(app, `${this.env}-${this.repo}-${this.key}`, {
       org: this.org,
       env: this.env,
       key: this.key,

--- a/src/vault.ts
+++ b/src/vault.ts
@@ -6,7 +6,7 @@ const pexec = util.promisify(oexec);
 const ARGS = process.argv.slice(3);
 const OPTIONS = require('simple-argv')
 
-const STACK_TYPE = process.env.STACK_TYPE || 'aws-eks-ec2-asg';
+const STACK_TYPE = process.env.STACK_TYPE || 'do-k8s';
 const STACK_TEAM = process.env.OPS_TEAM_NAME || 'private'
 
 async function init() {
@@ -462,7 +462,6 @@ async function bulk() {
         vaultMapObj[mKey]=mVal;
       }
     }
-    
     for (var vKey in vaultMapObj) {
       vaultKeysList = `${vaultKeysList}\n ${vKey}`;
     }
@@ -502,9 +501,9 @@ async function bulk() {
 
     const encode = (str: string):string => Buffer.from(str, 'binary').toString('base64');
     const data = JSON.parse(vault.stdout); 
-    
+
     for (var vKey in vaultMapObj) {
-    
+
       console.log(`\n🔐 Setting ${vKey} to ${vaultMapObj[vKey]} on the ${VAULT_KEY} with type ${typeof vaultMapObj[vKey]}`)
       data.data[vKey] = encode(vaultMapObj[vKey].toString())
 
@@ -515,8 +514,8 @@ async function bulk() {
     const payload = JSON.stringify(data)
     await pexec(`echo '${payload}' | kubectl apply -f -`) 
     console.log(`✅ Bulk set/update was succesful\n`)
-    
-    
+
+
   } catch (e) {
     console.log('there was an error:', e)
   }
@@ -556,10 +555,11 @@ switch(ARGS[0]) {
   break;
 
   case "bulk":
-
+  
     bulk()
 
   break;
+  
   case "help":
   default:
     console.log("\n ⛔️ No sub command provided. See available subcommands:\n")


### PR DESCRIPTION
### Kubernetes Cluster Capacity/Scale Setup
This PR is more like a proposal since it include some changes that allow us to define the capacity of the Kubernetes cluster depending on the environment and taking this values from the `config` in the CTO's team. The definition of the size of the cluster is given in the following 3 `config` parameters:

- **DO_DEV_K8S_CONFIG** 
- **DO_STG_K8S_CONFIG**
- **DO_PRD_K8S_CONFIG**

One parameter for each environment, this config parameter is a string cotaining a `json` in the following format:

```
{ 
 "dropletSize": "s-1vcpu-2gb", 
 "nodeCount": 3, 
 “minNodes": 1, 
 "maxNodes": 5, 
 "autoScale": true 
}
```
### Redis Cluster Capacity/Scale Setup
The same aproach can be used for other resources, like in this case a `redis` cluster which is defined by the following parameters:

- **DO_DEV_REDIS_CONFIG** 
- **DO_STG_REDIS_CONFIG**
- **DO_PRD_REDIS_CONFIG**

In this case the redis clustre config string has the following format.

```
{ 
  "dropletSize": "db-s-1vcpu-1gb", 
  "nodeCount": 1, 
  ”version": "6" 
}
```
### Services Parameters Definition
For many use cases we need to setup multiple services in the same cluster, so I thought that we can store the service deployment paramenters like port, replicas, etc. as `config` parameter in CTO's teams, it would makes deployments easier for developers. The variables as shown before would be bye environment as follows.

- **DO_DEV_SERVICES** 
- **DO_STG_SERVICES**
- **DO_PRD_SERVICES**

It containes an array of services with parameters in `json` format.

```
{ 
	"sample-app": 
		{ 
			"replicas" : 2, 
			"ports" : [ { 
				"containerPort" : 3000 
			} ], 
			"lb_ports" : [ { 
				"protocol": "TCP", 
				"port": 3000, 
				"targetPort": 3000 
			} ], 
			"hc_port": 3000 
		 }
}
```
### Maping vault secrets to environment variables in a pod
Since in many cases you have to deploy multiple services using the same vault, you can find cases in which a varable name is the same for different services and generates conflicts, in order to solve this issue I added a parameter `map` in the json string for services that allows you to map this variables. following is the json for a sample service.

```
{ 
	"sample-expressjs": { 
				"replicas" : 2, 
				"ports" : [ { 
					"containerPort" : 3000 
					} ], 
				"lb_ports" : [ {
					 "protocol": "TCP", 
					"port": 3000, 
					"targetPort": 3000 
					} ], 
				"hc_port": 3000, 
				"sticky_sessions": "no",
				"map": { 
					"DB_HOST" : "SP_DB_HOST", 
					"DB_USER":"SP_DB_USER", 
					"DB_PASS":"SP_DB_PASS", 
					"DB_PORT":"SP_DB_PORT", 
					"DB_NAME":"SP_DB_NAME"
				}
	 } 
}
```
each pair maps **pod env variable** to **vault variable** so for example **DB_HOST** in the pod going to have the value of **SP_DB_HOST** from the vault.
All feedback is welcome.