### PR TITLE
Enhanced Deployment Prompting

### DIFF
--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -1,0 +1,78 @@
+import {Answers, Questions, ux} from '@cto.ai/sdk';
+
+export function stackEnvPrompt () {
+    return ux.prompt < {
+        STACK_ENV: string
+    } > ({
+        type: 'list',
+        name: 'STACK_ENV',
+        choices: ['dev', 'stg', 'prd', 'all'],
+        default: 'dev',
+        message: 'What is the name of the environment?',
+    })
+}
+
+export function stackRepoPrompt () {
+    return ux.prompt < {
+        STACK_REPO: string
+    } > ({
+        type: 'list',
+        name: 'STACK_REPO',
+        choices: ['sample-expressjs-do-k8s-cdktf'],
+        default: 'sample-expressjs-do-k8s-cdktf',
+        message: 'What is the name of the application repo?',
+    })
+}
+
+export function stackTagPrompt (tags: string[] = [], defaultValue?: string | number) {
+    const questions: Questions = tags.length > 0
+    ? {
+        type: 'list',
+        name: 'STACK_TAG',
+        message: 'What is the name of the tag or branch?',
+        choices: tags
+    }
+    : {
+        type: 'input',
+        name: 'STACK_TAG',
+        message: 'What is the name of the tag or branch?',
+        allowEmpty: false
+    }
+    return ux.prompt < {
+        STACK_TAG: string
+    }>(questions)
+}
+
+export function stackOperationPrompt() {
+    return ux.prompt < {
+        OPERATION: string,
+    } > ({
+        type: 'list',
+        name: 'OPERATION',
+        default: 'service',
+        choices: ['service', 'cluster'],
+        message: 'Do you want to destroy cluster or a service?'
+    })
+}
+
+export function secretValuePrompt () {
+    return ux.prompt < {
+        SECRET_VALUE: string
+    }>({
+        type: 'input',
+        name: 'SECRET_NAME',
+        message: 'What is the value for the secret?',
+        allowEmpty: false
+    })
+}
+
+export function secretKeyPrompt () {
+    return ux.prompt < {
+        SECRET_NAME: string
+    }>({
+        type: 'input',
+        name: 'SECRET_NAME',
+        message: 'What is the key for the secret?',
+        allowEmpty: false
+    })
+}

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -19,8 +19,8 @@ export function stackRepoPrompt () {
     } > ({
         type: 'list',
         name: 'STACK_REPO',
-        choices: ['sample-expressjs-do-k8s-cdktf'],
-        default: 'sample-expressjs-do-k8s-cdktf',
+        choices: ['sample-expressjs'],
+        default: 'sample-expressjs',
         message: 'What is the name of the application repo?',
     })
 }

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -1,5 +1,6 @@
 import {Answers, Questions, ux} from '@cto.ai/sdk';
 
+// TODO: Support choices as an arg for when 'all' is not an option i.e. vault workflow
 export function stackEnvPrompt () {
     return ux.prompt < {
         STACK_ENV: string


### PR DESCRIPTION
### 📖 User Story
As a user, I want to be prompted to select the available options for environment, repo & tag during deployment STIC avoid typing or copy pasting values that are prone to typos which would create unusable infra

### 👍 Acceptance Criteria
GIVEN that a user wants to deploy via each workflows-sh stack

WHEN they are prompted for env, repo or tag

THEN they should be provided with drop down lists of the given envs, repo and images that are available to them for deployment

:question_mark:  Assumptions
We can reference an eisting implementation from aws-ecs-fargate

This should work for aws-eks* as it uses aws CLI

For DO, GKE we’d need alternative options

### 🏗️ Proposed Tasks
Port the aws-* solution back to the core stacks

FIgure out how to approach this with DO registry

Define how to approach this for the Pulumi stacks